### PR TITLE
feat: nAdmin approvals, coordinators page, and dashboard enhancements

### DIFF
--- a/src/main/frontend-v2/src/app/router.tsx
+++ b/src/main/frontend-v2/src/app/router.tsx
@@ -50,6 +50,12 @@ const SessionsPage = lazy(() =>
 const PlaceholderPage = lazy(() =>
   import('@shared/components/PlaceholderPage').then((m) => ({ default: m.PlaceholderPage })),
 );
+const ApprovalsPage = lazy(() =>
+  import('@features/approvals/pages/ApprovalsPage').then((m) => ({ default: m.ApprovalsPage })),
+);
+const CoordinatorsPage = lazy(() =>
+  import('@features/approvals/pages/CoordinatorsPage').then((m) => ({ default: m.CoordinatorsPage })),
+);
 
 // Volunteer/Explore pages
 const MySessionsPage = lazy(() =>
@@ -132,6 +138,22 @@ export const router = createBrowserRouter([
         element: <AdminLayout />,
         children: [
           { index: true, element: <Navigate to="dashboard" replace /> },
+          {
+            path: 'approvals',
+            element: (
+              <SuspenseWrapper>
+                <ApprovalsPage />
+              </SuspenseWrapper>
+            ),
+          },
+          {
+            path: 'coordinators',
+            element: (
+              <SuspenseWrapper>
+                <CoordinatorsPage />
+              </SuspenseWrapper>
+            ),
+          },
           {
             path: 'dashboard',
             element: (

--- a/src/main/frontend-v2/src/config/roles.ts
+++ b/src/main/frontend-v2/src/config/roles.ts
@@ -88,12 +88,14 @@ export const ROLE_CONFIG: Record<UserRole, RoleConfig> = {
   },
   nAdmin: {
     label: 'Need Admin',
-    defaultRoute: '/app/dashboard',
+    defaultRoute: '/app/approvals',
     layout: 'admin',
     sidebarItems: [
+      { id: 'approvals', label: 'Approvals', path: '/app/approvals', icon: 'FactCheck' },
       { id: 'dashboard', label: 'Dashboard', path: '/app/dashboard', icon: 'Dashboard' },
       { id: 'needs', label: 'Needs', path: '/app/needs', icon: 'Assignment' },
       { id: 'entities', label: 'Entities', path: '/app/entities', icon: 'Business' },
+      { id: 'coordinators', label: 'Coordinators', path: '/app/coordinators', icon: 'People' },
       { id: 'sessions', label: 'Sessions', path: '/app/sessions', icon: 'CalendarMonth' },
       { id: 'settings', label: 'Settings', path: '/app/settings', icon: 'Settings' },
     ],

--- a/src/main/frontend-v2/src/features/approvals/index.ts
+++ b/src/main/frontend-v2/src/features/approvals/index.ts
@@ -1,0 +1,1 @@
+export { ApprovalsPage } from './pages/ApprovalsPage';

--- a/src/main/frontend-v2/src/features/approvals/pages/ApprovalsPage.tsx
+++ b/src/main/frontend-v2/src/features/approvals/pages/ApprovalsPage.tsx
@@ -1,0 +1,560 @@
+import { useState, useEffect } from 'react';
+import {
+  Box,
+  Typography,
+  Stack,
+  Paper,
+  Tabs,
+  Tab,
+  Chip,
+  Button,
+  Alert,
+  Skeleton,
+  TextField,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  InputAdornment,
+} from '@mui/material';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import CancelIcon from '@mui/icons-material/Cancel';
+import PersonIcon from '@mui/icons-material/Person';
+import BusinessIcon from '@mui/icons-material/Business';
+import AssignmentIcon from '@mui/icons-material/Assignment';
+import SearchIcon from '@mui/icons-material/Search';
+import { useAppSelector } from '@app/store';
+import { StatusChip } from '@features/dashboard/components/StatusChip';
+import { getAuthHeaders, getAuthHeadersWithJson } from '@shared/utils/authHeaders';
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL_NEED;
+
+// --- Types ---
+interface PendingCoordinator {
+  osid: string;
+  identityDetails?: { fullname?: string; name?: string; gender?: string };
+  contactDetails?: { email?: string; mobile?: string; address?: { city?: string; state?: string } };
+  status?: string;
+  role?: string[];
+  agencyId?: string;
+}
+
+interface PendingEntity {
+  id: string;
+  name: string;
+  registrationId?: string;
+  mobile?: string;
+  addressLine1?: string;
+  address_line1?: string;
+  district?: string;
+  state?: string;
+  category?: string;
+  status?: string;
+}
+
+interface PendingNeed {
+  id: string;
+  name: string;
+  status: string;
+  entityId?: string;
+  needTypeId?: string;
+  userId?: string;
+  description?: string;
+  needPurpose?: string;
+  entity?: { name?: string; district?: string };
+  needType?: { name?: string };
+  createdAt?: string;
+}
+
+type TabValue = 0 | 1 | 2 | 3 | 4;
+
+// --- Component ---
+export function ApprovalsPage() {
+  const user = useAppSelector((state) => state.user.data);
+  const userId = user?.osid || '';
+
+  const [loading, setLoading] = useState(true);
+  const [tab, setTab] = useState<TabValue>(0);
+  const [search, setSearch] = useState('');
+  const [success, setSuccess] = useState('');
+  const [error, setError] = useState('');
+
+  // Data
+  const [pendingCoordinators, setPendingCoordinators] = useState<PendingCoordinator[]>([]);
+  const [pendingEntities, setPendingEntities] = useState<PendingEntity[]>([]);
+  const [pendingNeeds, setPendingNeeds] = useState<PendingNeed[]>([]);
+  const [rejectedItems, setRejectedItems] = useState<{ type: string; item: PendingCoordinator | PendingEntity | PendingNeed }[]>([]);
+
+  // Reject dialog
+  const [rejectDialog, setRejectDialog] = useState(false);
+  const [rejectTarget, setRejectTarget] = useState<{ type: string; id: string; name: string } | null>(null);
+  const [rejectReason, setRejectReason] = useState('');
+  const [actionLoading, setActionLoading] = useState(false);
+
+  // Fetch all data
+  useEffect(() => {
+    async function fetchData() {
+      if (!userId) return;
+      setLoading(true);
+      try {
+        const headers = getAuthHeaders();
+
+        // 1. Get my entities
+        const entityResp = await fetch(
+          `${BASE_URL}/api/v1/serve-need/entityDetails/${userId}?page=0&size=1000`,
+          { headers },
+        );
+        let myEntities: PendingEntity[] = [];
+        if (entityResp.ok) {
+          const entityData = await entityResp.json();
+          myEntities = Array.isArray(entityData) ? entityData : (entityData.content || []);
+        }
+        const entityIds = myEntities.map((e) => e.id);
+
+        // Pending entities (status = New or Verified, not yet Active)
+        const pendingEnts = myEntities.filter((e) => e.status === 'New' || e.status === 'Verified');
+        setPendingEntities(pendingEnts);
+
+        // Rejected entities
+        const rejectedEnts = myEntities
+          .filter((e) => e.status === 'Inactive' || e.status === 'Rejected')
+          .map((e) => ({ type: 'entity', item: e }));
+
+        // 2. Get all users → filter coordinators assigned to my entities
+        const usersResp = await fetch(
+          `${BASE_URL}/api/v1/serve-volunteering/user/all-users`,
+          { headers },
+        );
+        let allUsers: PendingCoordinator[] = [];
+        if (usersResp.ok) {
+          allUsers = await usersResp.json();
+          if (!Array.isArray(allUsers)) allUsers = [];
+        }
+
+        // Filter nCoordinators — those with status Registered (pending approval)
+        // To scope to my entities: we'd need to know which coordinators are assigned to my entities
+        // For now, filter by agency (same agency) + status Registered
+        const pendingCoords = allUsers.filter(
+          (u) => u.role?.includes('nCoordinator') && u.status === 'Registered',
+        );
+        setPendingCoordinators(pendingCoords);
+
+        // Rejected coordinators
+        const rejectedCoords = allUsers
+          .filter((u) => u.role?.includes('nCoordinator') && (u.status === 'Rejected' || u.status === 'Inactive'))
+          .map((u) => ({ type: 'coordinator', item: u }));
+
+        // 3. Get pending needs (status = New) for my entities
+        const needsResp = await fetch(
+          `${BASE_URL}/api/v1/serve-need/need/?status=New&page=0&size=200`,
+          { headers },
+        );
+        let allNewNeeds: PendingNeed[] = [];
+        if (needsResp.ok) {
+          const needsData = await needsResp.json();
+          const content = Array.isArray(needsData) ? needsData : (needsData.content || []);
+          // Normalize: handle both flat and nested need format
+          allNewNeeds = content.map((n: Record<string, unknown>) => {
+            if (n.need && typeof n.need === 'object') {
+              const need = n.need as Record<string, unknown>;
+              return {
+                id: need.id as string,
+                name: need.name as string,
+                status: need.status as string,
+                entityId: need.entityId as string,
+                needTypeId: need.needTypeId as string,
+                userId: need.userId as string,
+                description: need.description as string,
+                needPurpose: need.needPurpose as string,
+                entity: n.entity as PendingNeed['entity'],
+                needType: n.needType as PendingNeed['needType'],
+                createdAt: need.createdAt as string,
+              };
+            }
+            return n as unknown as PendingNeed;
+          });
+        }
+
+        // Filter needs to only my entities
+        const myPendingNeeds = allNewNeeds.filter((n) => entityIds.includes(n.entityId || ''));
+        setPendingNeeds(myPendingNeeds);
+
+        // Rejected needs
+        const rejectedNeedsResp = await fetch(
+          `${BASE_URL}/api/v1/serve-need/need/?status=Rejected&page=0&size=200`,
+          { headers },
+        );
+        let rejectedNeedsList: { type: string; item: PendingNeed }[] = [];
+        if (rejectedNeedsResp.ok) {
+          const rejData = await rejectedNeedsResp.json();
+          const rejContent = Array.isArray(rejData) ? rejData : (rejData.content || []);
+          const normalized = rejContent.map((n: Record<string, unknown>) => {
+            if (n.need && typeof n.need === 'object') {
+              const need = n.need as Record<string, unknown>;
+              return { id: need.id, name: need.name, status: need.status, entityId: need.entityId, entity: n.entity, needType: n.needType } as unknown as PendingNeed;
+            }
+            return n as unknown as PendingNeed;
+          });
+          rejectedNeedsList = normalized
+            .filter((n: PendingNeed) => entityIds.includes(n.entityId || ''))
+            .map((n: PendingNeed) => ({ type: 'need', item: n }));
+        }
+
+        setRejectedItems([...rejectedCoords, ...rejectedEnts, ...rejectedNeedsList]);
+      } catch {
+        setError('Failed to load approvals data.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, [userId]);
+
+  // Actions
+  const handleApproveCoordinator = async (coord: PendingCoordinator) => {
+    setActionLoading(true);
+    setError('');
+    try {
+      await fetch(`${BASE_URL}/api/v1/serve-volunteering/user/${coord.osid}`, {
+        method: 'PUT',
+        headers: getAuthHeadersWithJson(),
+        body: JSON.stringify({ status: 'Active' }),
+      });
+      setPendingCoordinators((prev) => prev.filter((c) => c.osid !== coord.osid));
+      setSuccess(`Coordinator ${coord.identityDetails?.fullname || ''} approved.`);
+      setTimeout(() => setSuccess(''), 4000);
+    } catch { setError('Failed to approve coordinator.'); }
+    finally { setActionLoading(false); }
+  };
+
+  const handleActivateEntity = async (entity: PendingEntity) => {
+    setActionLoading(true);
+    setError('');
+    try {
+      await fetch(`${BASE_URL}/api/v1/serve-need/entity/edit/${entity.id}`, {
+        method: 'PUT',
+        headers: getAuthHeadersWithJson(),
+        body: JSON.stringify({ ...entity, status: 'Active' }),
+      });
+      setPendingEntities((prev) => prev.filter((e) => e.id !== entity.id));
+      setSuccess(`Entity "${entity.name}" activated.`);
+      setTimeout(() => setSuccess(''), 4000);
+    } catch { setError('Failed to activate entity.'); }
+    finally { setActionLoading(false); }
+  };
+
+  const handleApproveNeed = async (need: PendingNeed) => {
+    setActionLoading(true);
+    setError('');
+    try {
+      await fetch(`${BASE_URL}/api/v1/serve-need/need/status/${need.id}?status=Approved`, {
+        method: 'PUT',
+        headers: getAuthHeaders(),
+      });
+      setPendingNeeds((prev) => prev.filter((n) => n.id !== need.id));
+      setSuccess(`Need "${need.name}" approved.`);
+      setTimeout(() => setSuccess(''), 4000);
+    } catch { setError('Failed to approve need.'); }
+    finally { setActionLoading(false); }
+  };
+
+  const openRejectDialog = (type: string, id: string, name: string) => {
+    setRejectTarget({ type, id, name });
+    setRejectReason('');
+    setRejectDialog(true);
+  };
+
+  const handleRejectConfirm = async () => {
+    if (!rejectTarget || !rejectReason.trim()) { setError('Reason is required.'); return; }
+    setActionLoading(true);
+    setError('');
+    try {
+      if (rejectTarget.type === 'coordinator') {
+        await fetch(`${BASE_URL}/api/v1/serve-volunteering/user/${rejectTarget.id}`, {
+          method: 'PUT',
+          headers: getAuthHeadersWithJson(),
+          body: JSON.stringify({ status: 'Rejected' }),
+        });
+        setPendingCoordinators((prev) => prev.filter((c) => c.osid !== rejectTarget.id));
+      } else if (rejectTarget.type === 'entity') {
+        await fetch(`${BASE_URL}/api/v1/serve-need/entity/edit/${rejectTarget.id}`, {
+          method: 'PUT',
+          headers: getAuthHeadersWithJson(),
+          body: JSON.stringify({ status: 'Inactive' }),
+        });
+        setPendingEntities((prev) => prev.filter((e) => e.id !== rejectTarget.id));
+      } else if (rejectTarget.type === 'need') {
+        await fetch(`${BASE_URL}/api/v1/serve-need/need/status/${rejectTarget.id}?status=Rejected`, {
+          method: 'PUT',
+          headers: getAuthHeaders(),
+        });
+        setPendingNeeds((prev) => prev.filter((n) => n.id !== rejectTarget.id));
+      }
+      setSuccess(`"${rejectTarget.name}" rejected.`);
+      setRejectDialog(false);
+      setTimeout(() => setSuccess(''), 4000);
+    } catch { setError('Failed to reject.'); }
+    finally { setActionLoading(false); }
+  };
+
+  // Counts
+  const counts = {
+    all: pendingCoordinators.length + pendingEntities.length + pendingNeeds.length,
+    coordinators: pendingCoordinators.length,
+    entities: pendingEntities.length,
+    needs: pendingNeeds.length,
+    rejected: rejectedItems.length,
+  };
+
+  // Search filter
+  const filterBySearch = (name: string) => {
+    if (!search.trim()) return true;
+    return name.toLowerCase().includes(search.toLowerCase());
+  };
+
+  if (loading) {
+    return (
+      <Box>
+        <Typography variant="h4" fontWeight={600} sx={{ mb: 3 }}>Approvals</Typography>
+        <Stack spacing={2}>
+          {[1, 2, 3, 4].map((i) => <Skeleton key={i} variant="rounded" height={80} />)}
+        </Stack>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+        <Typography variant="h4" fontWeight={600}>Approvals</Typography>
+        {counts.all > 0 && (
+          <Chip label={`${counts.all} pending`} color="warning" size="small" />
+        )}
+      </Stack>
+
+      {success && <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess('')}>{success}</Alert>}
+      {error && <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>{error}</Alert>}
+
+      {/* Tabs */}
+      <Tabs
+        value={tab}
+        onChange={(_, v) => setTab(v)}
+        variant="scrollable"
+        scrollButtons="auto"
+        sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
+      >
+        <Tab label={`All (${counts.all})`} />
+        <Tab label={`Coordinators (${counts.coordinators})`} icon={<PersonIcon />} iconPosition="start" />
+        <Tab label={`Entities (${counts.entities})`} icon={<BusinessIcon />} iconPosition="start" />
+        <Tab label={`Needs (${counts.needs})`} icon={<AssignmentIcon />} iconPosition="start" />
+        <Tab label={`Rejected (${counts.rejected})`} />
+      </Tabs>
+
+      {/* Search */}
+      <TextField
+        size="small"
+        placeholder="Search..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        InputProps={{ startAdornment: <InputAdornment position="start"><SearchIcon fontSize="small" /></InputAdornment> }}
+        sx={{ mb: 2, maxWidth: 350 }}
+      />
+
+      {/* Empty state */}
+      {counts.all === 0 && tab !== 4 && (
+        <Paper sx={{ p: 4, textAlign: 'center' }}>
+          <CheckCircleIcon sx={{ fontSize: 48, color: 'success.main', mb: 1 }} />
+          <Typography variant="h6" fontWeight={600}>All caught up!</Typography>
+          <Typography variant="body2" color="text.secondary">No pending approvals right now.</Typography>
+        </Paper>
+      )}
+
+      {/* Pending Coordinators */}
+      {(tab === 0 || tab === 1) && pendingCoordinators.filter((c) => filterBySearch(c.identityDetails?.fullname || c.identityDetails?.name || '')).map((coord) => (
+        <Paper key={coord.osid} variant="outlined" sx={{ p: 2, mb: 1.5 }}>
+          <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" alignItems={{ sm: 'center' }} spacing={1}>
+            <Box>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <PersonIcon fontSize="small" color="primary" />
+                <Typography variant="subtitle2" fontWeight={600}>
+                  {coord.identityDetails?.fullname || coord.identityDetails?.name || '—'}
+                </Typography>
+                <Chip label="nCoordinator" size="small" variant="outlined" />
+              </Stack>
+              <Typography variant="caption" color="text.secondary">
+                {coord.contactDetails?.email || ''} · {coord.contactDetails?.mobile || ''} · {coord.contactDetails?.address?.city || ''}
+              </Typography>
+            </Box>
+            <Stack direction="row" spacing={1}>
+              <Button
+                size="small"
+                variant="contained"
+                color="success"
+                startIcon={<CheckCircleIcon />}
+                onClick={() => handleApproveCoordinator(coord)}
+                disabled={actionLoading}
+              >
+                Approve
+              </Button>
+              <Button
+                size="small"
+                variant="outlined"
+                color="error"
+                startIcon={<CancelIcon />}
+                onClick={() => openRejectDialog('coordinator', coord.osid, coord.identityDetails?.fullname || '')}
+                disabled={actionLoading}
+              >
+                Reject
+              </Button>
+            </Stack>
+          </Stack>
+        </Paper>
+      ))}
+
+      {/* Pending Entities */}
+      {(tab === 0 || tab === 2) && pendingEntities.filter((e) => filterBySearch(e.name)).map((entity) => (
+        <Paper key={entity.id} variant="outlined" sx={{ p: 2, mb: 1.5 }}>
+          <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" alignItems={{ sm: 'center' }} spacing={1}>
+            <Box>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <BusinessIcon fontSize="small" color="secondary" />
+                <Typography variant="subtitle2" fontWeight={600}>{entity.name}</Typography>
+                <StatusChip status={entity.status || 'New'} />
+              </Stack>
+              <Typography variant="caption" color="text.secondary">
+                {entity.addressLine1 || entity.address_line1 || ''} · {entity.district || ''} · {entity.category || ''}
+              </Typography>
+            </Box>
+            <Stack direction="row" spacing={1}>
+              <Button
+                size="small"
+                variant="contained"
+                color="success"
+                startIcon={<CheckCircleIcon />}
+                onClick={() => handleActivateEntity(entity)}
+                disabled={actionLoading}
+              >
+                Activate
+              </Button>
+              <Button
+                size="small"
+                variant="outlined"
+                color="error"
+                startIcon={<CancelIcon />}
+                onClick={() => openRejectDialog('entity', entity.id, entity.name)}
+                disabled={actionLoading}
+              >
+                Reject
+              </Button>
+            </Stack>
+          </Stack>
+        </Paper>
+      ))}
+
+      {/* Pending Needs */}
+      {(tab === 0 || tab === 3) && pendingNeeds.filter((n) => filterBySearch(n.name)).map((need) => (
+        <Paper key={need.id} variant="outlined" sx={{ p: 2, mb: 1.5 }}>
+          <Stack direction={{ xs: 'column', sm: 'row' }} justifyContent="space-between" alignItems={{ sm: 'center' }} spacing={1}>
+            <Box>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <AssignmentIcon fontSize="small" color="info" />
+                <Typography variant="subtitle2" fontWeight={600}>{need.name}</Typography>
+                <Chip label="New" size="small" color="info" variant="outlined" />
+              </Stack>
+              <Typography variant="caption" color="text.secondary">
+                {need.entity?.name || ''} · {need.needType?.name || ''} · {need.description || need.needPurpose || ''}
+              </Typography>
+            </Box>
+            <Stack direction="row" spacing={1}>
+              <Button
+                size="small"
+                variant="contained"
+                color="success"
+                startIcon={<CheckCircleIcon />}
+                onClick={() => handleApproveNeed(need)}
+                disabled={actionLoading}
+              >
+                Approve
+              </Button>
+              <Button
+                size="small"
+                variant="outlined"
+                color="error"
+                startIcon={<CancelIcon />}
+                onClick={() => openRejectDialog('need', need.id, need.name)}
+                disabled={actionLoading}
+              >
+                Reject
+              </Button>
+            </Stack>
+          </Stack>
+        </Paper>
+      ))}
+
+      {/* Rejected Tab */}
+      {tab === 4 && (
+        rejectedItems.length === 0 ? (
+          <Paper sx={{ p: 4, textAlign: 'center' }}>
+            <Typography variant="body2" color="text.secondary">No rejected items.</Typography>
+          </Paper>
+        ) : (
+          rejectedItems.filter((r) => {
+            const name = r.type === 'coordinator'
+              ? (r.item as PendingCoordinator).identityDetails?.fullname || ''
+              : r.type === 'entity'
+                ? (r.item as PendingEntity).name
+                : (r.item as PendingNeed).name;
+            return filterBySearch(name);
+          }).map((r, i) => {
+            const name = r.type === 'coordinator'
+              ? (r.item as PendingCoordinator).identityDetails?.fullname || (r.item as PendingCoordinator).identityDetails?.name || '—'
+              : r.type === 'entity'
+                ? (r.item as PendingEntity).name
+                : (r.item as PendingNeed).name;
+            const icon = r.type === 'coordinator' ? <PersonIcon fontSize="small" /> : r.type === 'entity' ? <BusinessIcon fontSize="small" /> : <AssignmentIcon fontSize="small" />;
+            return (
+              <Paper key={i} variant="outlined" sx={{ p: 2, mb: 1, opacity: 0.7 }}>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  {icon}
+                  <Typography variant="body2">{name}</Typography>
+                  <Chip label={r.type} size="small" variant="outlined" />
+                  <Chip label="Rejected" size="small" color="error" variant="outlined" />
+                </Stack>
+              </Paper>
+            );
+          })
+        )
+      )}
+
+      {/* Reject Dialog */}
+      <Dialog open={rejectDialog} onClose={() => setRejectDialog(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Reject — {rejectTarget?.name}</DialogTitle>
+        <DialogContent>
+          <TextField
+            label="Reason *"
+            value={rejectReason}
+            onChange={(e) => setRejectReason(e.target.value)}
+            fullWidth
+            multiline
+            rows={3}
+            size="small"
+            sx={{ mt: 1 }}
+            InputLabelProps={{ shrink: true }}
+            placeholder="Explain why this is being rejected..."
+          />
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setRejectDialog(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={handleRejectConfirm}
+            disabled={actionLoading || !rejectReason.trim()}
+          >
+            {actionLoading ? 'Rejecting...' : 'Reject'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/main/frontend-v2/src/features/approvals/pages/CoordinatorsPage.tsx
+++ b/src/main/frontend-v2/src/features/approvals/pages/CoordinatorsPage.tsx
@@ -1,0 +1,516 @@
+import { useState, useEffect, useMemo } from 'react';
+import {
+  Box,
+  Typography,
+  Stack,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TablePagination,
+  TextField,
+  InputAdornment,
+  Button,
+  Chip,
+  Skeleton,
+  Alert,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Grid,
+  Autocomplete,
+  Divider,
+  IconButton,
+  Tooltip,
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import PersonAddIcon from '@mui/icons-material/PersonAdd';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import BlockIcon from '@mui/icons-material/Block';
+import BusinessIcon from '@mui/icons-material/Business';
+import AssignmentIcon from '@mui/icons-material/Assignment';
+import { useAppSelector } from '@app/store';
+import { StatusChip } from '@features/dashboard/components/StatusChip';
+import { getAuthHeaders, getAuthHeadersWithJson } from '@shared/utils/authHeaders';
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL_NEED;
+
+// --- Types ---
+interface Coordinator {
+  osid: string;
+  identityDetails?: { fullname?: string; name?: string; gender?: string };
+  contactDetails?: { email?: string; mobile?: string; address?: { city?: string; state?: string } };
+  status?: string;
+  role?: string[];
+  agencyId?: string;
+}
+
+interface EntityItem {
+  id: string;
+  name: string;
+  status?: string;
+  district?: string;
+}
+
+// --- Component ---
+export function CoordinatorsPage() {
+  const user = useAppSelector((state) => state.user.data);
+  const userId = user?.osid || '';
+
+  const [loading, setLoading] = useState(true);
+  const [coordinators, setCoordinators] = useState<Coordinator[]>([]);
+  const [myEntities, setMyEntities] = useState<EntityItem[]>([]);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [success, setSuccess] = useState('');
+  const [error, setError] = useState('');
+  const [actionLoading, setActionLoading] = useState(false);
+
+  // Assign entity dialog
+  const [assignDialog, setAssignDialog] = useState(false);
+  const [assignTarget, setAssignTarget] = useState<Coordinator | null>(null);
+  const [selectedEntity, setSelectedEntity] = useState<EntityItem | null>(null);
+
+  // Detail dialog
+  const [detailCoord, setDetailCoord] = useState<Coordinator | null>(null);
+  const [coordEntities, setCoordEntities] = useState<EntityItem[]>([]);
+  const [coordNeeds, setCoordNeeds] = useState<{ id: string; name: string; status: string }[]>([]);
+  const [detailLoading, setDetailLoading] = useState(false);
+
+  // Fetch coordinators and entities
+  useEffect(() => {
+    async function fetchData() {
+      if (!userId) return;
+      setLoading(true);
+      try {
+        const headers = getAuthHeaders();
+
+        // Get my entities
+        const entityResp = await fetch(
+          `${BASE_URL}/api/v1/serve-need/entityDetails/${userId}?page=0&size=1000`,
+          { headers },
+        );
+        let entities: EntityItem[] = [];
+        if (entityResp.ok) {
+          const data = await entityResp.json();
+          entities = Array.isArray(data) ? data : (data.content || []);
+        }
+        setMyEntities(entities.filter((e) => e.status === 'Active'));
+
+        // Get all users → filter nCoordinators
+        const usersResp = await fetch(
+          `${BASE_URL}/api/v1/serve-volunteering/user/all-users`,
+          { headers },
+        );
+        let allUsers: Coordinator[] = [];
+        if (usersResp.ok) {
+          allUsers = await usersResp.json();
+          if (!Array.isArray(allUsers)) allUsers = [];
+        }
+
+        const coords = allUsers.filter((u) => u.role?.includes('nCoordinator'));
+        setCoordinators(coords);
+      } catch {
+        setError('Failed to load data.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, [userId]);
+
+  // Fetch coordinator detail
+  const handleRowClick = async (coord: Coordinator) => {
+    setDetailCoord(coord);
+    setDetailLoading(true);
+    setCoordEntities([]);
+    setCoordNeeds([]);
+    try {
+      const headers = getAuthHeaders();
+
+      // Get entities assigned to this coordinator
+      const entResp = await fetch(
+        `${BASE_URL}/api/v1/serve-need/entityDetails/${coord.osid}?page=0&size=100`,
+        { headers },
+      );
+      if (entResp.ok) {
+        const data = await entResp.json();
+        const ents = Array.isArray(data) ? data : (data.content || []);
+        setCoordEntities(ents.filter((e: EntityItem) => e.status !== 'Inactive'));
+      }
+
+      // Get needs raised by this coordinator
+      const needsResp = await fetch(
+        `${BASE_URL}/api/v1/serve-need/need/user/${coord.osid}?page=0&size=100&status=Assigned`,
+        { headers },
+      );
+      if (needsResp.ok) {
+        const data = await needsResp.json();
+        const content = Array.isArray(data) ? data : (data.content || []);
+        const needs = content.map((n: Record<string, unknown>) => ({
+          id: (n.id as string) || ((n.need as Record<string, unknown>)?.id as string) || '',
+          name: (n.name as string) || ((n.need as Record<string, unknown>)?.name as string) || '',
+          status: (n.status as string) || ((n.need as Record<string, unknown>)?.status as string) || '',
+        }));
+        setCoordNeeds(needs);
+      }
+    } catch { /* silent */ }
+    finally { setDetailLoading(false); }
+  };
+
+  // Stats
+  const stats = useMemo(() => {
+    const total = coordinators.length;
+    const active = coordinators.filter((c) => c.status === 'Active').length;
+    const pending = coordinators.filter((c) => c.status === 'Registered').length;
+    const inactive = coordinators.filter((c) => c.status === 'Inactive' || c.status === 'Rejected').length;
+    return { total, active, pending, inactive };
+  }, [coordinators]);
+
+  // Filter
+  const filtered = useMemo(() => {
+    let result = coordinators;
+    if (statusFilter !== 'all') {
+      if (statusFilter === 'pending') result = result.filter((c) => c.status === 'Registered');
+      else if (statusFilter === 'active') result = result.filter((c) => c.status === 'Active');
+      else if (statusFilter === 'inactive') result = result.filter((c) => c.status === 'Inactive' || c.status === 'Rejected');
+    }
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      result = result.filter((c) =>
+        (c.identityDetails?.fullname || '').toLowerCase().includes(q) ||
+        (c.identityDetails?.name || '').toLowerCase().includes(q) ||
+        (c.contactDetails?.email || '').toLowerCase().includes(q) ||
+        (c.contactDetails?.mobile || '').includes(q),
+      );
+    }
+    return result;
+  }, [coordinators, statusFilter, search]);
+
+  const paginated = filtered.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
+
+  // Actions
+  const handleApprove = async (coord: Coordinator) => {
+    setActionLoading(true);
+    try {
+      await fetch(`${BASE_URL}/api/v1/serve-volunteering/user/${coord.osid}`, {
+        method: 'PUT',
+        headers: getAuthHeadersWithJson(),
+        body: JSON.stringify({ status: 'Active' }),
+      });
+      setCoordinators((prev) => prev.map((c) => c.osid === coord.osid ? { ...c, status: 'Active' } : c));
+      setSuccess(`${coord.identityDetails?.fullname || ''} approved.`);
+      setTimeout(() => setSuccess(''), 4000);
+    } catch { setError('Failed to approve.'); }
+    finally { setActionLoading(false); }
+  };
+
+  const handleDeactivate = async (coord: Coordinator) => {
+    setActionLoading(true);
+    try {
+      await fetch(`${BASE_URL}/api/v1/serve-volunteering/user/${coord.osid}`, {
+        method: 'PUT',
+        headers: getAuthHeadersWithJson(),
+        body: JSON.stringify({ status: 'Inactive' }),
+      });
+      setCoordinators((prev) => prev.map((c) => c.osid === coord.osid ? { ...c, status: 'Inactive' } : c));
+      setSuccess(`Coordinator deactivated.`);
+      setTimeout(() => setSuccess(''), 4000);
+    } catch { setError('Failed to deactivate.'); }
+    finally { setActionLoading(false); }
+  };
+
+  const handleAssignEntity = async () => {
+    if (!assignTarget || !selectedEntity) return;
+    setActionLoading(true);
+    try {
+      await fetch(`${BASE_URL}/api/v1/serve-need/entity/assign`, {
+        method: 'POST',
+        headers: getAuthHeadersWithJson(),
+        body: JSON.stringify({
+          entityId: selectedEntity.id,
+          userId: assignTarget.osid,
+        }),
+      });
+      setSuccess(`Entity "${selectedEntity.name}" assigned to ${assignTarget.identityDetails?.fullname || ''}.`);
+      setAssignDialog(false);
+      setSelectedEntity(null);
+      setTimeout(() => setSuccess(''), 4000);
+    } catch { setError('Failed to assign entity.'); }
+    finally { setActionLoading(false); }
+  };
+
+  return (
+    <Box>
+      <Typography variant="h4" fontWeight={600} sx={{ mb: 3 }}>Coordinators</Typography>
+
+      {success && <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess('')}>{success}</Alert>}
+      {error && <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>{error}</Alert>}
+
+      {/* Stats */}
+      <Grid container spacing={2} sx={{ mb: 3 }}>
+        <Grid item xs={6} sm={3}>
+          <Paper
+            sx={{ p: 2, textAlign: 'center', cursor: 'pointer', border: statusFilter === 'all' ? '2px solid' : '1px solid', borderColor: statusFilter === 'all' ? 'primary.main' : 'divider' }}
+            onClick={() => { setStatusFilter('all'); setPage(0); }}
+          >
+            <Typography variant="h5" fontWeight={700} color="primary.main">{stats.total}</Typography>
+            <Typography variant="caption" color="text.secondary">Total</Typography>
+          </Paper>
+        </Grid>
+        <Grid item xs={6} sm={3}>
+          <Paper
+            sx={{ p: 2, textAlign: 'center', cursor: 'pointer', border: statusFilter === 'pending' ? '2px solid' : '1px solid', borderColor: statusFilter === 'pending' ? 'warning.main' : 'divider' }}
+            onClick={() => { setStatusFilter('pending'); setPage(0); }}
+          >
+            <Typography variant="h5" fontWeight={700} color="warning.main">{stats.pending}</Typography>
+            <Typography variant="caption" color="text.secondary">Pending</Typography>
+          </Paper>
+        </Grid>
+        <Grid item xs={6} sm={3}>
+          <Paper
+            sx={{ p: 2, textAlign: 'center', cursor: 'pointer', border: statusFilter === 'active' ? '2px solid' : '1px solid', borderColor: statusFilter === 'active' ? 'success.main' : 'divider' }}
+            onClick={() => { setStatusFilter('active'); setPage(0); }}
+          >
+            <Typography variant="h5" fontWeight={700} color="success.main">{stats.active}</Typography>
+            <Typography variant="caption" color="text.secondary">Active</Typography>
+          </Paper>
+        </Grid>
+        <Grid item xs={6} sm={3}>
+          <Paper
+            sx={{ p: 2, textAlign: 'center', cursor: 'pointer', border: statusFilter === 'inactive' ? '2px solid' : '1px solid', borderColor: statusFilter === 'inactive' ? 'error.main' : 'divider' }}
+            onClick={() => { setStatusFilter('inactive'); setPage(0); }}
+          >
+            <Typography variant="h5" fontWeight={700} color="error.main">{stats.inactive}</Typography>
+            <Typography variant="caption" color="text.secondary">Inactive</Typography>
+          </Paper>
+        </Grid>
+      </Grid>
+
+      {/* Search */}
+      <TextField
+        size="small"
+        placeholder="Search by name, email, phone..."
+        value={search}
+        onChange={(e) => { setSearch(e.target.value); setPage(0); }}
+        InputProps={{ startAdornment: <InputAdornment position="start"><SearchIcon fontSize="small" /></InputAdornment> }}
+        sx={{ mb: 2, maxWidth: 400 }}
+      />
+
+      {/* Table */}
+      <Paper>
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ fontWeight: 600 }}>Name</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Email</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Phone</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>City</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Status</TableCell>
+                <TableCell sx={{ fontWeight: 600 }} align="center">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {loading ? (
+                Array.from({ length: 5 }).map((_, i) => (
+                  <TableRow key={i}>{Array.from({ length: 6 }).map((_, j) => <TableCell key={j}><Skeleton /></TableCell>)}</TableRow>
+                ))
+              ) : paginated.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} align="center" sx={{ py: 6 }}>
+                    <Typography variant="body2" color="text.secondary">No coordinators found</Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                paginated.map((coord) => (
+                  <TableRow key={coord.osid} hover sx={{ cursor: 'pointer' }} onClick={() => handleRowClick(coord)}>
+                    <TableCell>
+                      <Typography variant="body2" fontWeight={500}>
+                        {coord.identityDetails?.fullname || coord.identityDetails?.name || '—'}
+                      </Typography>
+                    </TableCell>
+                    <TableCell><Typography variant="caption">{coord.contactDetails?.email || '—'}</Typography></TableCell>
+                    <TableCell><Typography variant="caption">{coord.contactDetails?.mobile || '—'}</Typography></TableCell>
+                    <TableCell><Typography variant="caption">{coord.contactDetails?.address?.city || '—'}</Typography></TableCell>
+                    <TableCell><StatusChip status={coord.status || 'Registered'} /></TableCell>
+                    <TableCell align="center" onClick={(e) => e.stopPropagation()}>
+                      <Stack direction="row" spacing={0.5} justifyContent="center">
+                        {coord.status === 'Registered' && (
+                          <Tooltip title="Approve">
+                            <IconButton size="small" color="success" onClick={() => handleApprove(coord)} disabled={actionLoading}>
+                              <CheckCircleIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        )}
+                        <Tooltip title="Assign Entity">
+                          <IconButton size="small" color="primary" onClick={() => { setAssignTarget(coord); setAssignDialog(true); }}>
+                            <BusinessIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                        {coord.status === 'Active' && (
+                          <Tooltip title="Deactivate">
+                            <IconButton size="small" color="error" onClick={() => handleDeactivate(coord)} disabled={actionLoading}>
+                              <BlockIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        )}
+                      </Stack>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <TablePagination
+          component="div"
+          count={filtered.length}
+          page={page}
+          onPageChange={(_, p) => setPage(p)}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={(e) => { setRowsPerPage(parseInt(e.target.value, 10)); setPage(0); }}
+          rowsPerPageOptions={[10, 15, 25]}
+        />
+      </Paper>
+
+      {/* Assign Entity Dialog */}
+      <Dialog open={assignDialog} onClose={() => setAssignDialog(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Assign Entity to {assignTarget?.identityDetails?.fullname || ''}</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <Typography variant="body2" color="text.secondary">
+              Select an entity to assign to this coordinator:
+            </Typography>
+            <Autocomplete
+              options={myEntities}
+              getOptionLabel={(option) => `${option.name}${option.district ? ` · ${option.district}` : ''}`}
+              value={selectedEntity}
+              onChange={(_, val) => setSelectedEntity(val)}
+              renderInput={(params) => (
+                <TextField {...params} label="Select Entity" placeholder="Search entities..." size="small" />
+              )}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setAssignDialog(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            startIcon={<PersonAddIcon />}
+            onClick={handleAssignEntity}
+            disabled={actionLoading || !selectedEntity}
+          >
+            {actionLoading ? 'Assigning...' : 'Assign'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Coordinator Detail Dialog */}
+      <Dialog open={Boolean(detailCoord)} onClose={() => setDetailCoord(null)} maxWidth="sm" fullWidth>
+        {detailCoord && (
+          <>
+            <DialogTitle>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <Typography variant="h6" fontWeight={600}>
+                  {detailCoord.identityDetails?.fullname || detailCoord.identityDetails?.name || '—'}
+                </Typography>
+                <StatusChip status={detailCoord.status || 'Registered'} />
+              </Stack>
+            </DialogTitle>
+            <DialogContent>
+              {detailLoading ? (
+                <Stack spacing={2}><Skeleton height={60} /><Skeleton height={60} /></Stack>
+              ) : (
+                <Stack spacing={3}>
+                  {/* Profile */}
+                  <Box>
+                    <Typography variant="subtitle2" color="text.secondary" gutterBottom>Contact</Typography>
+                    <Grid container spacing={1}>
+                      <Grid item xs={6}>
+                        <Typography variant="caption" color="text.secondary">Email</Typography>
+                        <Typography variant="body2">{detailCoord.contactDetails?.email || '—'}</Typography>
+                      </Grid>
+                      <Grid item xs={6}>
+                        <Typography variant="caption" color="text.secondary">Phone</Typography>
+                        <Typography variant="body2">{detailCoord.contactDetails?.mobile || '—'}</Typography>
+                      </Grid>
+                      <Grid item xs={6}>
+                        <Typography variant="caption" color="text.secondary">City</Typography>
+                        <Typography variant="body2">{detailCoord.contactDetails?.address?.city || '—'}</Typography>
+                      </Grid>
+                    </Grid>
+                  </Box>
+
+                  <Divider />
+
+                  {/* Assigned Entities */}
+                  <Box>
+                    <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                      Assigned Entities ({coordEntities.length})
+                    </Typography>
+                    {coordEntities.length > 0 ? (
+                      <Stack direction="row" flexWrap="wrap" gap={1}>
+                        {coordEntities.map((e) => (
+                          <Chip key={e.id} icon={<BusinessIcon />} label={e.name} size="small" variant="outlined" />
+                        ))}
+                      </Stack>
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">No entities assigned yet.</Typography>
+                    )}
+                  </Box>
+
+                  <Divider />
+
+                  {/* Needs raised */}
+                  <Box>
+                    <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                      Needs Raised ({coordNeeds.length})
+                    </Typography>
+                    {coordNeeds.length > 0 ? (
+                      <Stack spacing={0.5}>
+                        {coordNeeds.slice(0, 10).map((n) => (
+                          <Stack key={n.id} direction="row" spacing={1} alignItems="center">
+                            <AssignmentIcon fontSize="small" color="action" />
+                            <Typography variant="body2">{n.name}</Typography>
+                            <StatusChip status={n.status} />
+                          </Stack>
+                        ))}
+                        {coordNeeds.length > 10 && (
+                          <Typography variant="caption" color="text.secondary">+{coordNeeds.length - 10} more</Typography>
+                        )}
+                      </Stack>
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">No needs raised yet.</Typography>
+                    )}
+                  </Box>
+                </Stack>
+              )}
+            </DialogContent>
+            <DialogActions sx={{ px: 3, pb: 2 }}>
+              {detailCoord.status === 'Registered' && (
+                <Button variant="contained" color="success" onClick={() => { handleApprove(detailCoord); setDetailCoord(null); }}>
+                  Approve
+                </Button>
+              )}
+              <Button
+                variant="outlined"
+                startIcon={<BusinessIcon />}
+                onClick={() => { setAssignTarget(detailCoord); setAssignDialog(true); setDetailCoord(null); }}
+              >
+                Assign Entity
+              </Button>
+              <Button onClick={() => setDetailCoord(null)}>Close</Button>
+            </DialogActions>
+          </>
+        )}
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/main/frontend-v2/src/features/dashboard/pages/NAdminDashboard.tsx
+++ b/src/main/frontend-v2/src/features/dashboard/pages/NAdminDashboard.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Grid,
   Stack,
@@ -18,6 +19,8 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  Button,
+  Alert,
 } from '@mui/material';
 import AssignmentIcon from '@mui/icons-material/Assignment';
 import PlayCircleIcon from '@mui/icons-material/PlayCircle';
@@ -51,6 +54,7 @@ import {
 import { WelcomeBanner } from '../components/WelcomeBanner';
 import { StatCard } from '../components/StatCard';
 import { StatusChip } from '../components/StatusChip';
+import { getAuthHeaders } from '@shared/utils/authHeaders';
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL_NEED;
 
@@ -130,8 +134,12 @@ const PIE_COLORS = ['#3B82F6', '#10B981', '#EF4444', '#F59E0B', '#8B5CF6', '#EC4
 
 // --- Component ---
 export function NAdminDashboard() {
+  const navigate = useNavigate();
   const user = useAppSelector((state) => state.user.data);
   const userId = user?.osid || '';
+
+  // Pending approval counts
+  const [pendingCounts, setPendingCounts] = useState({ coordinators: 0, entities: 0, needs: 0 });
   const userName = user?.identityDetails?.fullname || user?.identityDetails?.name || 'Admin';
   const isSAdmin = user?.role?.includes('sAdmin');
 
@@ -310,6 +318,37 @@ export function NAdminDashboard() {
     fetchSessions();
   }, [userId]);
 
+  // Fetch pending approval counts
+  useEffect(() => {
+    async function fetchPendingCounts() {
+      if (!userId) return;
+      try {
+        const headers = getAuthHeaders();
+        // Pending entities
+        const entResp = await fetch(`${BASE_URL}/api/v1/serve-need/entityDetails/${userId}?page=0&size=1000`, { headers });
+        let pendingEnts = 0;
+        if (entResp.ok) {
+          const data = await entResp.json();
+          const ents = Array.isArray(data) ? data : (data.content || []);
+          pendingEnts = ents.filter((e: { status?: string }) => e.status === 'New' || e.status === 'Verified').length;
+        }
+        // Pending coordinators
+        const usersResp = await fetch(`${BASE_URL}/api/v1/serve-volunteering/user/all-users`, { headers });
+        let pendingCoords = 0;
+        if (usersResp.ok) {
+          const users = await usersResp.json();
+          if (Array.isArray(users)) {
+            pendingCoords = users.filter((u: { role?: string[]; status?: string }) => u.role?.includes('nCoordinator') && u.status === 'Registered').length;
+          }
+        }
+        // Pending needs (already have from needs data)
+        const pendingNeedsCount = needs.filter((n) => n.status === 'New').length;
+        setPendingCounts({ coordinators: pendingCoords, entities: pendingEnts, needs: pendingNeedsCount });
+      } catch { /* silent */ }
+    }
+    fetchPendingCounts();
+  }, [userId, needs]);
+
   // Filter deliverables by period
   const sessionStats = useMemo(() => {
     const { start, end } = getDateRange(sessionPeriod);
@@ -387,6 +426,25 @@ export function NAdminDashboard() {
         name={userName}
         subtitle={`Managing ${entities.length} entities · AY ${selectedYear}`}
       />
+
+      {/* Action Required Banner */}
+      {(pendingCounts.coordinators + pendingCounts.entities + pendingCounts.needs) > 0 && (
+        <Alert
+          severity="warning"
+          action={
+            <Button size="small" color="inherit" onClick={() => navigate('/app/approvals')}>
+              Go to Approvals →
+            </Button>
+          }
+        >
+          <strong>Action Required:</strong>{' '}
+          {pendingCounts.coordinators > 0 && `${pendingCounts.coordinators} coordinator${pendingCounts.coordinators > 1 ? 's' : ''} pending`}
+          {pendingCounts.coordinators > 0 && (pendingCounts.entities > 0 || pendingCounts.needs > 0) && ' · '}
+          {pendingCounts.entities > 0 && `${pendingCounts.entities} entit${pendingCounts.entities > 1 ? 'ies' : 'y'} pending`}
+          {pendingCounts.entities > 0 && pendingCounts.needs > 0 && ' · '}
+          {pendingCounts.needs > 0 && `${pendingCounts.needs} need${pendingCounts.needs > 1 ? 's' : ''} pending`}
+        </Alert>
+      )}
 
       {/* Filters Row */}
       <Paper sx={{ p: 2 }}>

--- a/src/main/frontend-v2/src/shared/components/Sidebar.tsx
+++ b/src/main/frontend-v2/src/shared/components/Sidebar.tsx
@@ -14,6 +14,7 @@ import PeopleIcon from '@mui/icons-material/People';
 import BusinessIcon from '@mui/icons-material/Business';
 import CorporateFareIcon from '@mui/icons-material/CorporateFare';
 import SettingsIcon from '@mui/icons-material/Settings';
+import FactCheckIcon from '@mui/icons-material/FactCheck';
 import { SidebarItem } from '@config/roles';
 
 // Map icon string names to MUI icon components
@@ -25,6 +26,7 @@ const ICON_MAP: Record<string, React.ReactElement> = {
   Business: <BusinessIcon />,
   CorporateFare: <CorporateFareIcon />,
   Settings: <SettingsIcon />,
+  FactCheck: <FactCheckIcon />,
 };
 
 interface SidebarProps {


### PR DESCRIPTION
- Add Approvals page as nAdmin default landing (approve/reject coordinators, entities, needs)
- Add Coordinators management page (approve, assign entity, deactivate, view detail)
- Add action required banner on nAdmin dashboard with pending counts
- Update sidebar: Approvals first, add Coordinators
- Fix session data: skip inactive plans, filter PlannedPause, use deliverable JSONB for time/link
- Fix auth headers on all fetch calls for production
- Fix Keycloak role parsing (filter to app roles only)
- Add session link management in SessionsPanel
- Add volunteer nomination restriction (1 pending max)
- Add Volunteer Home page with journey overview
- Add Volunteer Journey page (/app/volunteers/:id)
- Enhance vCoordinator/vAdmin dashboards with action items and funnel
- Add recharts dependency for charting